### PR TITLE
Fixed being unable to move and the terminal field being null

### DIFF
--- a/TerminalPlus/ScrollbarGarbage.cs
+++ b/TerminalPlus/ScrollbarGarbage.cs
@@ -95,20 +95,16 @@ namespace TerminalPlus
                     currentScrollPosition = 1f;
                     currentStep = loopCount = 0;
                     ___m_Content.anchoredPosition = Vector2.zero;
-                    mls.LogDebug("SUBMIT LOOP");
                 }
                 else if (terminalKeyPressed)
                 {
                     currentScrollPosition = 0f;
                     currentStep = totalSteps;
-                    mls.LogDebug("TYPING LOOP");
                 }
                 else
                 {
                     currentScrollPosition = Mathf.Clamp01(1f - ((float)currentStep / totalSteps));
-                    mls.LogDebug("NORMAL LOOP");
                 }
-                mls.LogDebug($"STEP {currentStep} of {totalSteps} - currentValue = {currentScrollPosition}");
 
                 __instance.verticalNormalizedPosition = currentScrollPosition;
             }

--- a/TerminalPlus/ScrollbarGarbage.cs
+++ b/TerminalPlus/ScrollbarGarbage.cs
@@ -24,7 +24,7 @@ namespace TerminalPlus
         [HarmonyPostfix]
         public static void Ssdfdwesasd(float input, bool sendCallback)
         {
-            if (terminal.terminalInUse)
+            if (terminal != null && terminal.terminalInUse)
             {
                 StackTrace stackTrace = new StackTrace();
 
@@ -39,7 +39,7 @@ namespace TerminalPlus
         [HarmonyPostfix]
         public static void TUPatch(ref float ___timeSinceLastKeyboardPress, Terminal __instance)
         {
-            if (terminal.terminalInUse)
+            if (__instance.terminalInUse)
             {
                 __instance.scrollBarCanvasGroup.alpha = 1;
                 terminalKeyPressed = ___timeSinceLastKeyboardPress < 0.08;
@@ -68,7 +68,7 @@ namespace TerminalPlus
         [HarmonyPostfix]
         public static void ScrollTest(Vector2 offset, ref Bounds ___m_ContentBounds, ref Bounds ___m_ViewBounds, ref RectTransform ___m_Content, ref Vector2 ___m_PrevPosition, ScrollRect __instance)
         {
-            if (terminal.terminalInUse)
+            if (terminal != null && terminal.terminalInUse)
             {
                 __instance.verticalScrollbarVisibility = ScrollbarVisibility.AutoHideAndExpandViewport;
 

--- a/TerminalPlus/Setup/SortingNodes.cs
+++ b/TerminalPlus/Setup/SortingNodes.cs
@@ -21,8 +21,7 @@ namespace TerminalPlus
         // By Price: moonsList.Sort((x, y) => moonsPrice[x.levelID].CompareTo(moonsPrice[y.levelID]));
         // By Weather: moonsList.Sort((x, y) => x.currentWeather.CompareTo(y.currentWeather));
 
-        public static readonly Terminal terminal = UnityEngine.Object.FindAnyObjectByType<Terminal>();
-        public static readonly ScrollRect scrollRect = UnityEngine.Object.FindAnyObjectByType<ScrollRect>();
+        public static Terminal terminal = UnityEngine.Object.FindAnyObjectByType<Terminal>();
         private static string[] nounTPList = new string[0];
 
         public static int dayPowerMult = 0;

--- a/TerminalPlus/TerminalPatch.cs
+++ b/TerminalPlus/TerminalPatch.cs
@@ -33,6 +33,7 @@ namespace TerminalPlus
         [HarmonyPriority(Priority.First)]
         public static void PatchHelpPage(Terminal __instance)
         {
+            terminal = __instance;
             //terminal.terminalNodes.specialNodes[13].displayText = new Nodes().MainHelpPage();
             //terminal.screenText.caretBlinkRate = 1f; //__instance.screenText.caretBlinkRate = 1f;
             __instance.scrollBarCanvasGroup.transform.localPosition = new Vector3(246, 196.5f, 0); // default: 245ish, 208ish, 0


### PR DESCRIPTION
- Fixed v1.1.0 causing you to be unable to move and spamming errors (due to `terminal` not being updated therefore being `null`).
- Removed debug log spam when typing