### PR TITLE
Don't Destroy Moons

### DIFF
--- a/TerminalPlus/Setup/MoonInfo.cs
+++ b/TerminalPlus/Setup/MoonInfo.cs
@@ -95,9 +95,7 @@ namespace TerminalPlus
 
             for(int i = errorArray.Count - 1; i >= 0; i--)
             {
-                mls.LogWarning("destroying dupe: " + errorArray[i].name);
                 moonsList.Remove(errorArray[i]);
-                UnityEngine.Object.Destroy(errorArray[i]);
             }
             IDChecker.Clear();
 


### PR DESCRIPTION
Fixed the mod destroying the TestAllEnemies moon which is used to initialize some things in vanilla and some mods. I believe the test level is also the default level when joining a lobby since I have the following exception when re-hosting a lobby:
```
NullReferenceException: Object reference not set to an instance of an object
at StartOfRound.SceneManager_OnLoadComplete1 (System.UInt64 clientId, System.String sceneName, UnityEngine.SceneManagement.LoadSceneMode loadSceneMode) [0x00006] in <255c0877f9414c3aa6f1fe5079ac13f3>:0 
at Unity.Netcode.NetworkSceneManager.OnServerLoadedScene (System.UInt32 sceneEventId, UnityEngine.SceneManagement.Scene scene) [0x001b9] in <895801699cfc4b4ab52267f31e2a4998>:0 
at Unity.Netcode.NetworkSceneManager.OnSceneLoaded (System.UInt32 sceneEventId) [0x00091] in <895801699cfc4b4ab52267f31e2a4998>:0 
at Unity.Netcode.SceneEventProgress.<SetAsyncOperation>b__37_0 (UnityEngine.AsyncOperation asyncOp2) [0x00012] in <895801699cfc4b4ab52267f31e2a4998>:0 
at UnityEngine.AsyncOperation.InvokeCompletionEvent () [0x0000f] in <e27997765c1848b09d8073e5d642717a>:0
```